### PR TITLE
Flakey specs caused by inconsistency in how configuration gets reset between specs

### DIFF
--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 RSpec.describe Throttling do
   before do
-    Throttling.reset_defaults!
     @storage = Throttling.storage = TestStorage.new
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,11 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 
+  # Reset Throttling configuration after every spec.
+  config.after do
+    Throttling.reset_defaults!
+  end
+
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/throttling_spec.rb
+++ b/spec/throttling_spec.rb
@@ -1,10 +1,6 @@
 require "spec_helper"
 
 RSpec.describe Throttling do
-  after :each do
-    Throttling.reset_defaults!
-  end
-
   context "with defaults" do
     it "should create logger" do
       expect(Throttling.logger).to be_a(Logger)


### PR DESCRIPTION
Example:

```
Failures:

  1) Throttling.for should raise an exception if no throttling_limits found in config
     Failure/Error: expect { Throttling.for("foo") }.to raise_error(ArgumentError)
       expected ArgumentError but nothing was raised
     # ./spec/throttling_spec.rb:64:in `block (3 levels) in <top (required)>'

```